### PR TITLE
Fix builder to emit correct states when Idle

### DIFF
--- a/platform_android/authentication/src/main/kotlin/co/joebirch/minimise/authentication/AuthenticationFragment.kt
+++ b/platform_android/authentication/src/main/kotlin/co/joebirch/minimise/authentication/AuthenticationFragment.kt
@@ -11,12 +11,13 @@ import co.joebirch.minimise.authentication.di.inject
 import co.joebirch.minimise.authentication.util.AuthenticationValidator
 import javax.inject.Inject
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 
 class AuthenticationFragment : BaseFragment() {
 
-    @Inject lateinit var viewModelFactory: ViewModelFactory
-    @Inject lateinit var authenticatonValidator: AuthenticationValidator
+    @Inject
+    lateinit var viewModelFactory: ViewModelFactory
+    @Inject
+    lateinit var authenticatonValidator: AuthenticationValidator
 
     private val authenticationViewModel: AuthenticationViewModel by viewModels {
         viewModelFactory

--- a/platform_android/authentication/src/main/kotlin/co/joebirch/minimise/authentication/AuthenticationViewModel.kt
+++ b/platform_android/authentication/src/main/kotlin/co/joebirch/minimise/authentication/AuthenticationViewModel.kt
@@ -18,7 +18,7 @@ class AuthenticationViewModel @Inject constructor(
 
     private val uiState =
         MutableLiveData<AuthenticationState>().default(
-            AuthenticationState.Idle
+            AuthenticationState.Idle()
         )
 
     fun observeAuthenticationState(): LiveData<AuthenticationState> = uiState

--- a/platform_android/authentication/src/main/kotlin/co/joebirch/minimise/authentication/reset_password/ResetPasswordViewModel.kt
+++ b/platform_android/authentication/src/main/kotlin/co/joebirch/minimise/authentication/reset_password/ResetPasswordViewModel.kt
@@ -17,7 +17,7 @@ class ResetPasswordViewModel @Inject constructor(
 
     private val uiState =
         MutableLiveData<AuthenticationState>().default(
-            AuthenticationState.Idle)
+            AuthenticationState.Idle())
     fun observeAuthenticationState(): LiveData<AuthenticationState> = uiState
 
     override fun resetPassword(emailAddress: String) {

--- a/shared/SharedAuthentication/src/commonMain/kotlin/co.joebirch.minimise.authentication/AuthenticationState.kt
+++ b/shared/SharedAuthentication/src/commonMain/kotlin/co.joebirch.minimise.authentication/AuthenticationState.kt
@@ -9,7 +9,14 @@ sealed class AuthenticationState(
     val errorMessage: String? = null
 ) {
 
-    object Idle : AuthenticationState()
+    data class Idle(
+        val userEmail: String = "",
+        val userPassword: String = "",
+        val mode: AuthenticateMode = AuthenticateMode.SignUp
+    ) : AuthenticationState(
+        emailAddress = userEmail, password = userPassword,
+        authenticationMode = mode
+    )
 
     data class Loading(
         val userEmail: String,
@@ -47,7 +54,7 @@ sealed class AuthenticationState(
             } else if (success == true) {
                 Success
             } else {
-                Idle
+                Idle(emailAddress, password, authenticateMode)
             }
         }
     }


### PR DESCRIPTION
When the Idle state was being emitted, the authentication mode / login details weren't being set correctly. Now whenever the Idle state is returned, we set the values of the AuthenticationState properties