### PR TITLE
Improve gradle build files for shared modules

### DIFF
--- a/FirebaseAuthentication/build.gradle.kts
+++ b/FirebaseAuthentication/build.gradle.kts
@@ -23,41 +23,51 @@ kotlin {
 
     jvm("android")
 
-    sourceSets["commonMain"].dependencies {
-        implementation(Deps.Kotlin.common)
-        implementation(Deps.Kotlin.kotlinSerialization)
-        implementation(Deps.Kotlin.stdLib)
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(Deps.Kotlin.common)
+                implementation(Deps.Kotlin.kotlinSerialization)
+                implementation(Deps.Kotlin.stdLib)
 
-        implementation(Deps.Ktor.clientCore)
-        implementation(Deps.Ktor.clientJson)
-        implementation(Deps.Ktor.clientSerialization)
-    }
+                implementation(Deps.Ktor.clientCore)
+                implementation(Deps.Ktor.clientJson)
+                implementation(Deps.Ktor.clientSerialization)
+            }
+        }
 
-    sourceSets["commonTest"].dependencies {
-        implementation(Deps.Ktor.clientMock)
-        implementation(Deps.Ktor.clintMockJvm)
-        implementation(Deps.Ktor.clientMockNative)
+        val commonTest by getting {
+            dependencies {
+                implementation(Deps.Ktor.clientMock)
+                implementation(Deps.Ktor.clintMockJvm)
+                implementation(Deps.Ktor.clientMockNative)
 
-        implementation(kotlin("test"))
-        implementation(kotlin("test-junit"))
-        implementation(Deps.junit)
-        implementation(Deps.Coroutines.core)
-        implementation(Deps.Coroutines.test)
-    }
+                implementation(kotlin("test"))
+                implementation(kotlin("test-junit"))
+                implementation(Deps.junit)
+                implementation(Deps.Coroutines.core)
+                implementation(Deps.Coroutines.test)
+            }
+        }
 
-    sourceSets["androidMain"].dependencies {
-        implementation(Deps.Kotlin.serializationRuntime)
-        implementation(Deps.Ktor.clientAndroid)
-        implementation(Deps.Ktor.clientJsonJvm)
-        implementation(Deps.Ktor.clientSerializationJvm)
-        implementation(Deps.Ktor.clientOkhttp)
-    }
+        val androidMain by getting {
+            dependencies {
+                implementation(Deps.Kotlin.serializationRuntime)
+                implementation(Deps.Ktor.clientAndroid)
+                implementation(Deps.Ktor.clientJsonJvm)
+                implementation(Deps.Ktor.clientSerializationJvm)
+                implementation(Deps.Ktor.clientOkhttp)
+            }
+        }
 
-    sourceSets["iosMain"].dependencies {
-        implementation(Deps.Ktor.clientIos)
-        implementation(Deps.Ktor.clientSerializationNative)
-        implementation(Deps.Kotlin.serializationRuntimeNative)
+        val iosMain by getting {
+            dependencies {
+                implementation(Deps.Ktor.clientIos)
+                implementation(Deps.Ktor.clientSerializationNative)
+                implementation(Deps.Kotlin.serializationRuntimeNative)
 
-        implementation(Deps.Ktor.clientJsonNative)
+                implementation(Deps.Ktor.clientJsonNative)
+            }
+        }
     }
 }

--- a/shared/SharedAuthentication/build.gradle.kts
+++ b/shared/SharedAuthentication/build.gradle.kts
@@ -3,8 +3,8 @@ import co.joebirch.minimise.buildsrc.Deps
 import co.joebirch.minimise.buildsrc.Versions
 
 plugins {
-    id("org.jetbrains.kotlin.native.cocoapods")
     kotlin("multiplatform")
+    id("org.jetbrains.kotlin.native.cocoapods")
 }
 
 repositories {
@@ -13,6 +13,8 @@ repositories {
     mavenCentral()
 }
 
+version = "1.0"
+group = "co.joebirch.minimise.authentication"
 
 kotlin {
     val iOSTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
@@ -20,70 +22,61 @@ kotlin {
             ::iosArm64
         else
             ::iosX64
+    jvm("android")
 
     iOSTarget("ios") {
         binaries {
-            framework("Authentication") {
-                baseName = "Authentication"
+            framework("SharedAuthentication") {
+                baseName = "SharedAuthentication"
             }
         }
     }
 
-    jvm("android")
-
-    sourceSets["commonMain"].dependencies {
-        implementation(Deps.Kotlin.common)
-        implementation(Deps.Coroutines.core)
-        implementation(Deps.Coroutines.coreCommon)
-        implementation(project(":shared:SharedCommon"))
-        implementation(project(":FirebaseAuthentication"))
+    cocoapods {
+        summary = "Shared Authentication"
+        homepage = "https://github.com/hitherejoe/minimise"
     }
 
-    sourceSets["commonTest"].dependencies {
-        implementation(project(":FirebaseAuthentication"))
-        implementation(kotlin("test"))
-        implementation(kotlin("test-junit"))
-        implementation(Deps.junit)
-        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3")
-        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.3")
-    }
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(Deps.Kotlin.common)
+                implementation(Deps.Coroutines.coreCommon)
+                implementation(project(":shared:SharedCommon"))
+                implementation(project(":FirebaseAuthentication"))
+            }
+        }
 
-    sourceSets["androidMain"].dependencies {
-        implementation(Deps.Kotlin.stdLib)
-        implementation(Deps.Coroutines.android)
-    }
+        val commonTest by getting {
+            dependencies {
+                implementation(project(":FirebaseAuthentication"))
+                implementation(kotlin("test"))
+                implementation(kotlin("test-junit"))
+                implementation(Deps.junit)
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.5")
+            }
+        }
 
-    sourceSets["iosMain"].dependencies {
-        implementation(Deps.Kotlin.stdLib)
-        implementation(Deps.Coroutines.native)
-    }
-}
+        val mobileMain by creating {
+            dependsOn(commonMain)
+        }
 
-val packForXcode by tasks.creating(Sync::class) {
-    val targetDir = File(buildDir, "xcode-frameworks")
+        val androidMain by getting {
+            dependsOn(mobileMain)
+            dependencies {
+                implementation(Deps.Kotlin.stdLib)
+                implementation(Deps.Coroutines.android)
+                implementation(Deps.Coroutines.core)
+            }
+        }
 
-    /// selecting the right configuration for the iOS
-    /// framework depending on the environment
-    /// variables set by Xcode build
-    val mode = System.getenv("CONFIGURATION") ?: "DEBUG"
-    val framework = kotlin.targets
-        .getByName<KotlinNativeTarget>("ios")
-        .binaries.getFramework(mode)
-    inputs.property("mode", mode)
-    dependsOn(framework.linkTask)
-
-    from({ framework.outputDirectory })
-    into(targetDir)
-
-    /// generate a helpful ./gradlew wrapper with embedded Java path
-    doLast {
-        val gradlew = File(targetDir, "gradlew")
-        gradlew.writeText("#!/bin/bash\n"
-                + "export 'JAVA_HOME=${System.getProperty("java.home")}'\n"
-                + "cd '${rootProject.rootDir}'\n"
-                + "./gradlew \$@\n")
-        gradlew.setExecutable(true)
+        val iosMain by getting {
+            dependsOn(mobileMain)
+            dependencies {
+                implementation(Deps.Kotlin.stdLib)
+                implementation(Deps.Coroutines.native)
+            }
+        }
     }
 }
-
-tasks.getByName("build").dependsOn(packForXcode)


### PR DESCRIPTION
Remove unused dependencies and gradle task declarations from the build files, in preparation for cocoapod support